### PR TITLE
Implement Furi message queue

### DIFF
--- a/crates/flipperzero/Cargo.toml
+++ b/crates/flipperzero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipperzero"
-version = "0.1.0"
+version = "0.1.1"
 description = "Rust for Flipper Zero"
 repository = "https://github.com/dcoles/flipperzero-rs"
 license = "MIT"

--- a/crates/flipperzero/src/furi.rs
+++ b/crates/flipperzero/src/furi.rs
@@ -1,5 +1,7 @@
 //! High-level bindings to Furi kernel
 
+use core::ffi::c_void;
+
 use flipperzero_sys as sys;
 pub struct Stdout;
 
@@ -35,6 +37,107 @@ pub fn sleep(duration: core::time::Duration) {
             sys::furi::delay_us(duration.as_micros() as u32);
         } else {
             sys::furi::delay_ms(duration.as_millis() as u32);
+        }
+    }
+}
+
+/// Error codes returned from Furi function calls
+#[derive(Debug)]
+pub enum Error {
+    /// General runtime error, corresponds to FuriStatusError
+    Generic,
+    /// Timeout was exceeded, corresponds to FuriStatusErrorTimeout
+    Timeout,
+    // Resource not available, corresponds to FuriStatusErrorResource
+    Resource,
+    // Parameter error, corresponds to FuriStatusErrorParameter
+    Parameter,
+    // System is out of memory, corresponds to FuriStatusErrorNoMemory
+    NoMemory,
+    // Not allowed in ISR context, corresponds to FuriStatusErrorISR
+    ISR,
+    // Unrecognized error code.
+    Other(u32),
+}
+
+impl From<u32> for Error {
+    fn from(code: u32) -> Self {
+        match i32::from_le_bytes(code.to_le_bytes()) {
+            -1 => Error::Generic,
+            -2 => Error::Timeout,
+            -3 => Error::Resource,
+            -4 => Error::Parameter,
+            -5 => Error::NoMemory,
+            -6 => Error::ISR,
+
+            _ => Error::Other(code)
+        }
+    }
+}
+
+/// Furi result type
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// MessageQueue provides a safe wrapper around the furi message queue primitive.
+pub struct MessageQueue<M: Sized> {
+    hnd: *const sys::message_queue::FuriMessageQueue,
+    _marker: core::marker::PhantomData<M>,
+}
+
+impl<M: Sized> MessageQueue<M> {
+    /// Constructs a message queue with the given capacity.
+    pub fn new(capacity: u32) -> Self {
+        Self {
+            hnd: unsafe { sys::message_queue::alloc(capacity, core::mem::size_of::<M>()) },
+            _marker: core::marker::PhantomData::<M>,
+        }
+    }
+
+    // Attempts to add the message to the end of the queue, waiting up to timeout ticks.
+    pub fn put(&self, mut msg: M, timeout_ticks: u32) -> Result<()> {
+        let code = unsafe {
+            sys::message_queue::put(self.hnd, &mut msg as *mut _ as *const c_void, timeout_ticks)
+        };
+
+        match code {
+            0 => Ok(()),
+            _ => Err(code.into()),
+        }
+    }
+
+    // Attempts to read a message from the front of the queue within timeout ticks.
+    pub fn get(&self, timeout_ticks: u32) -> Result<M> {
+        let mut out = core::mem::MaybeUninit::<M>::uninit();
+        let code = unsafe {
+            sys::message_queue::get(self.hnd, out.as_mut_ptr() as *mut c_void, timeout_ticks)
+        };
+
+        match code {
+            0 => Ok(unsafe { out.assume_init() }),
+            _ => Err(code.into()),
+        }
+    }
+
+    /// Returns the capacity of the queue.
+    pub fn capacity(&self) -> u32 {
+        unsafe { sys::message_queue::capacity(self.hnd) }
+    }
+
+    /// Returns the number of elements in the queue.
+    pub fn len(&self) -> u32 {
+        unsafe { sys::message_queue::count(self.hnd) }
+    }
+
+    /// Returns the number of free slots in the queue.
+    pub fn space(&self) -> u32 {
+        unsafe { sys::message_queue::space(self.hnd) }
+    }
+}
+
+impl<M: Sized> Drop for MessageQueue<M> {
+    fn drop(&mut self) {
+        unsafe {
+            sys::message_queue::free(self.hnd)
         }
     }
 }

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipperzero-sys"
-version = "0.1.0"
+version = "0.1.1"
 description = "Rust for Flipper Zero"
 repository = "https://github.com/dcoles/flipperzero-rs"
 license = "MIT"

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod canvas;
 pub mod furi;
 pub mod gui;
+pub mod message_queue;
 pub mod view_port;
 
 /// Declare an opaque type.

--- a/crates/sys/src/message_queue.rs
+++ b/crates/sys/src/message_queue.rs
@@ -1,0 +1,30 @@
+//! Low-level bindings to Furi message queue API
+
+use core::ffi::c_void;
+
+use crate::opaque;
+
+opaque!(FuriMessageQueue);
+
+extern "C" {
+    #[link_name = "furi_message_queue_alloc"]
+    pub fn alloc(count: u32, size: usize) -> *const FuriMessageQueue;
+
+    #[link_name = "furi_message_queue_free"]
+    pub fn free(queue: *const FuriMessageQueue);
+
+    #[link_name = "furi_message_queue_put"]
+    pub fn put(queue: *const FuriMessageQueue, payload: *const c_void, timeout: u32) -> u32;
+
+    #[link_name = "furi_message_queue_get"]
+    pub fn get(queue: *const FuriMessageQueue, payload: *mut c_void, timeout: u32) -> u32;
+
+    #[link_name = "furi_message_queue_get_capacity"]
+    pub fn capacity(queue: *const FuriMessageQueue) -> u32;
+
+    #[link_name = "furi_message_queue_get_count"]
+    pub fn count(queue: *const FuriMessageQueue) -> u32;
+
+    #[link_name = "furi_message_queue_get_space"]
+    pub fn space(queue: *const FuriMessageQueue) -> u32;
+}


### PR DESCRIPTION
Heya, love youre work! I have a bunch of plugin ideas I want to work on, so if its okay with you I'd like to implement them and send them to you as PRs.

Just to get my feet wet I've implemented the low-level message queue API, I have ideas around how to wrap it up neatly in a safe generic type but I'll save that for another PR.

Tested like this:

```rust
#[repr(C)]
#[derive(Debug)]
struct msg(u8);

let queue = message_queue::alloc(8, core::mem::size_of::<msg>());

write!(&mut stdout, "Queue capacity/count/space: {:?}/{:?}/{:?}\r\n", message_queue::capacity(queue), message_queue::count(queue), message_queue::space(queue)).unwrap();
stdout.flush().unwrap();

message_queue::put(queue, &mut msg(1) as *mut _ as *const c_void, 9999999);

write!(&mut stdout, "Queue capacity/count/space: {:?}/{:?}/{:?}\r\n", message_queue::capacity(queue), message_queue::count(queue), message_queue::space(queue)).unwrap();
stdout.flush().unwrap();

let mut output = msg(0);
message_queue::get(queue, &mut output as *mut _ as *mut c_void, 9999999);

write!(&mut stdout, "Read back: {:?}\r\n", output).unwrap();
write!(&mut stdout, "Queue capacity/count/space: {:?}/{:?}/{:?}\r\n", message_queue::capacity(queue), message_queue::count(queue), message_queue::space(queue)).unwrap();
stdout.flush().unwrap();
```

getting output:

![image](https://user-images.githubusercontent.com/6328589/193188159-9b5f9d09-faf4-40eb-8079-b854a99d455c.png)
