### PR TITLE
0.2-dev: Implement message_queue, fix Stdout.flush

### DIFF
--- a/crates/flipperzero/src/furi/io.rs
+++ b/crates/flipperzero/src/furi/io.rs
@@ -18,7 +18,7 @@ impl core::fmt::Write for Stdout {
 impl Stdout {
     pub fn flush(&mut self) -> core::fmt::Result {
         unsafe {
-            if !sys::furi::thread::stdout_flush().is_ok() {
+            if sys::furi::thread::stdout_flush().is_err() {
                 return Err(core::fmt::Error);
             }
         }

--- a/crates/flipperzero/src/furi/message_queue.rs
+++ b/crates/flipperzero/src/furi/message_queue.rs
@@ -1,0 +1,67 @@
+use core::ffi::c_void;
+use flipperzero_sys::furi::message_queue;
+use crate::furi::Result;
+
+/// MessageQueue provides a safe wrapper around the furi message queue primitive.
+pub struct MessageQueue<M: Sized> {
+    hnd: *const message_queue::FuriMessageQueue,
+    _marker: core::marker::PhantomData<M>,
+}
+
+impl<M: Sized> MessageQueue<M> {
+    /// Constructs a message queue with the given capacity.
+    pub fn new(capacity: u32) -> Self {
+        Self {
+            hnd: unsafe { message_queue::alloc(capacity, core::mem::size_of::<M>()) },
+            _marker: core::marker::PhantomData::<M>,
+        }
+    }
+
+    // Attempts to add the message to the end of the queue, waiting up to timeout ticks.
+    pub fn put(&self, mut msg: M, timeout_ticks: u32) -> Result<()> {
+        let status = unsafe {
+            message_queue::put(self.hnd, &mut msg as *mut _ as *const c_void, timeout_ticks)
+        };
+
+        match status.is_ok() {
+            true => Ok(()),
+            _ => Err(status),
+        }
+    }
+
+    // Attempts to read a message from the front of the queue within timeout ticks.
+    pub fn get(&self, timeout_ticks: u32) -> Result<M> {
+        let mut out = core::mem::MaybeUninit::<M>::uninit();
+        let status = unsafe {
+            message_queue::get(self.hnd, out.as_mut_ptr() as *mut c_void, timeout_ticks)
+        };
+
+        match status.is_ok() {
+            true => Ok(unsafe { out.assume_init() }),
+            _ => Err(status),
+        }
+    }
+
+    /// Returns the capacity of the queue.
+    pub fn capacity(&self) -> u32 {
+        unsafe { message_queue::capacity(self.hnd) }
+    }
+
+    /// Returns the number of elements in the queue.
+    pub fn len(&self) -> u32 {
+        unsafe { message_queue::count(self.hnd) }
+    }
+
+    /// Returns the number of free slots in the queue.
+    pub fn space(&self) -> u32 {
+        unsafe { message_queue::space(self.hnd) }
+    }
+}
+
+impl<M: Sized> Drop for MessageQueue<M> {
+    fn drop(&mut self) {
+        unsafe {
+            message_queue::free(self.hnd)
+        }
+    }
+}

--- a/crates/flipperzero/src/furi/mod.rs
+++ b/crates/flipperzero/src/furi/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod io;
 pub mod sync;
+pub mod message_queue;
 pub mod thread;
 
 use flipperzero_sys as sys;

--- a/crates/sys/src/furi/base.rs
+++ b/crates/sys/src/furi/base.rs
@@ -30,6 +30,11 @@ impl Status {
     pub fn is_ok(self) -> bool {
         self == status::OK
     }
+
+    /// Did the operation error?
+    pub fn is_err(self) -> bool {
+        self != status::OK
+    }
 }
 
 impl Display for Status {

--- a/crates/sys/src/furi/message_queue.rs
+++ b/crates/sys/src/furi/message_queue.rs
@@ -1,0 +1,31 @@
+//! Low-level bindings to Furi message queue API
+
+use core::ffi::c_void;
+
+use crate::furi::base::Status;
+use crate::opaque;
+
+opaque!(FuriMessageQueue);
+
+extern "C" {
+    #[link_name = "furi_message_queue_alloc"]
+    pub fn alloc(count: u32, size: usize) -> *const FuriMessageQueue;
+
+    #[link_name = "furi_message_queue_free"]
+    pub fn free(queue: *const FuriMessageQueue);
+
+    #[link_name = "furi_message_queue_put"]
+    pub fn put(queue: *const FuriMessageQueue, payload: *const c_void, timeout: u32) -> Status;
+
+    #[link_name = "furi_message_queue_get"]
+    pub fn get(queue: *const FuriMessageQueue, payload: *mut c_void, timeout: u32) -> Status;
+
+    #[link_name = "furi_message_queue_get_capacity"]
+    pub fn capacity(queue: *const FuriMessageQueue) -> u32;
+
+    #[link_name = "furi_message_queue_get_count"]
+    pub fn count(queue: *const FuriMessageQueue) -> u32;
+
+    #[link_name = "furi_message_queue_get_space"]
+    pub fn space(queue: *const FuriMessageQueue) -> u32;
+}

--- a/crates/sys/src/furi/message_queue.rs
+++ b/crates/sys/src/furi/message_queue.rs
@@ -9,7 +9,7 @@ opaque!(FuriMessageQueue);
 
 extern "C" {
     #[link_name = "furi_message_queue_alloc"]
-    pub fn alloc(count: u32, size: usize) -> *const FuriMessageQueue;
+    pub fn alloc(count: usize, size: usize) -> *const FuriMessageQueue;
 
     #[link_name = "furi_message_queue_free"]
     pub fn free(queue: *const FuriMessageQueue);

--- a/crates/sys/src/furi/mod.rs
+++ b/crates/sys/src/furi/mod.rs
@@ -5,5 +5,6 @@ pub mod check;
 pub mod kernel;
 pub mod memmgr;
 pub mod mutex;
+pub mod message_queue;
 pub mod record;
 pub mod thread;


### PR DESCRIPTION
Rebased from #1.

```rust
let queue: MessageQueue<msg> = MessageQueue::new(8);
write!(&mut stdout, "Queue capacity/count/space: {:?}/{:?}/{:?}\r\n", queue.capacity(), queue.len(), queue.space()).unwrap();


queue.put(msg(69), 9999999).unwrap();
write!(&mut stdout, "Queue capacity/count/space: {:?}/{:?}/{:?}\r\n", queue.capacity(), queue.len(), queue.space()).unwrap();

let output = queue.get(9999999);
write!(&mut stdout, "Read back: {:?}\r\n", output.unwrap()).unwrap();
write!(&mut stdout, "Queue capacity/count/space: {:?}/{:?}/{:?}\r\n", queue.capacity(), queue.len(), queue.space()).unwrap();
stdout.flush().unwrap();
```