### PR TITLE
Memory allocator

### DIFF
--- a/crates/flipperzero/src/alloc.rs
+++ b/crates/flipperzero/src/alloc.rs
@@ -1,0 +1,55 @@
+use core::alloc::{GlobalAlloc, Layout};
+use core::ffi::c_void;
+
+use flipperzero_sys::c_string;
+use flipperzero_sys::furi;
+
+extern "C" {
+    #[link_name = "free"]
+    pub fn free(p: *mut c_void);
+
+    #[link_name = "aligned_malloc"]
+    pub fn aligned_malloc(size: usize, align: usize) -> *mut *mut c_void;
+
+    #[link_name = "realloc"]
+    pub fn realloc(p: *mut c_void, size: usize) -> *mut c_void;
+}
+
+pub struct FuriAlloc;
+
+unsafe impl GlobalAlloc for FuriAlloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        aligned_malloc(
+            layout.size(),
+            layout.align().max(core::mem::size_of::<usize>()),
+        ) as *mut u8
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        free(ptr as *mut c_void);
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // https://github.com/flipperdevices/flipperzero-firmware/issues/1747#issuecomment-1253636552
+        self.alloc(layout)
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
+        realloc(ptr as *mut c_void, new_size) as *mut u8
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: FuriAlloc = FuriAlloc;
+
+#[alloc_error_handler]
+fn on_oom(_layout: Layout) -> ! {
+    unsafe {
+        furi::thread_yield();
+        furi::crash(c_string!("Rust: Out of Memory\r\n"))
+    }
+}

--- a/crates/flipperzero/src/alloc.rs
+++ b/crates/flipperzero/src/alloc.rs
@@ -5,13 +5,8 @@ use flipperzero_sys::c_string;
 use flipperzero_sys::furi;
 
 extern "C" {
-    #[link_name = "free"]
-    pub fn free(p: *mut c_void);
-
-    #[link_name = "aligned_malloc"]
-    pub fn aligned_malloc(size: usize, align: usize) -> *mut *mut c_void;
-
-    #[link_name = "realloc"]
+    pub fn aligned_free(p: *mut c_void);
+    pub fn aligned_malloc(size: usize, align: usize) -> *mut c_void;
     pub fn realloc(p: *mut c_void, size: usize) -> *mut c_void;
 }
 
@@ -20,15 +15,12 @@ pub struct FuriAlloc;
 unsafe impl GlobalAlloc for FuriAlloc {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        aligned_malloc(
-            layout.size(),
-            layout.align().max(core::mem::size_of::<usize>()),
-        ) as *mut u8
+        aligned_malloc(layout.size(), layout.align()) as *mut u8
     }
 
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        free(ptr as *mut c_void);
+        aligned_free(ptr as *mut c_void);
     }
 
     #[inline]

--- a/crates/flipperzero/src/furi_alloc.rs
+++ b/crates/flipperzero/src/furi_alloc.rs
@@ -5,9 +5,12 @@ use flipperzero_sys::c_string;
 use flipperzero_sys::furi;
 
 extern "C" {
-    pub fn aligned_free(p: *mut c_void);
-    pub fn aligned_malloc(size: usize, align: usize) -> *mut c_void;
-    pub fn realloc(p: *mut c_void, size: usize) -> *mut c_void;
+    fn aligned_free(p: *mut c_void);
+    fn aligned_malloc(size: usize, align: usize) -> *mut c_void;
+    fn realloc(p: *mut c_void, size: usize) -> *mut c_void;
+    fn memmgr_get_total_heap() -> usize;
+    fn memmgr_get_free_heap() -> usize;
+    fn memmgr_get_minimum_free_heap() -> usize;
 }
 
 pub struct FuriAlloc;
@@ -45,3 +48,16 @@ fn on_oom(_layout: Layout) -> ! {
         furi::crash(c_string!("Rust: Out of Memory\r\n"))
     }
 }
+
+pub fn get_total_heap() -> usize {
+    unsafe { memmgr_get_total_heap() }
+}
+
+pub fn get_free_heap() -> usize {
+    unsafe { memmgr_get_free_heap() }
+}
+
+pub fn get_minimum_free_heap() -> usize {
+    unsafe { memmgr_get_minimum_free_heap() }
+}
+

--- a/crates/flipperzero/src/furi_alloc.rs
+++ b/crates/flipperzero/src/furi_alloc.rs
@@ -1,6 +1,5 @@
 use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::c_void;
-use core::{cmp, ptr};
 
 use flipperzero_sys::c_string;
 use flipperzero_sys::furi;

--- a/crates/flipperzero/src/furi_alloc.rs
+++ b/crates/flipperzero/src/furi_alloc.rs
@@ -1,5 +1,6 @@
 use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::c_void;
+use core::{cmp, ptr};
 
 use flipperzero_sys::c_string;
 use flipperzero_sys::furi;
@@ -7,7 +8,6 @@ use flipperzero_sys::furi;
 extern "C" {
     fn aligned_free(p: *mut c_void);
     fn aligned_malloc(size: usize, align: usize) -> *mut c_void;
-    fn realloc(p: *mut c_void, size: usize) -> *mut c_void;
     fn memmgr_get_total_heap() -> usize;
     fn memmgr_get_free_heap() -> usize;
     fn memmgr_get_minimum_free_heap() -> usize;
@@ -30,11 +30,6 @@ unsafe impl GlobalAlloc for FuriAlloc {
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         // https://github.com/flipperdevices/flipperzero-firmware/issues/1747#issuecomment-1253636552
         self.alloc(layout)
-    }
-
-    #[inline]
-    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
-        realloc(ptr as *mut c_void, new_size) as *mut u8
     }
 }
 

--- a/crates/flipperzero/src/lib.rs
+++ b/crates/flipperzero/src/lib.rs
@@ -1,6 +1,8 @@
 //! High-level bindings for the Flipper Zero.
 
 #![no_std]
+#![feature(alloc_error_handler)]
 
 pub mod furi;
 pub mod panic_handler;
+pub mod alloc;

--- a/crates/flipperzero/src/lib.rs
+++ b/crates/flipperzero/src/lib.rs
@@ -5,4 +5,4 @@
 
 pub mod furi;
 pub mod panic_handler;
-pub mod alloc;
+pub mod furi_alloc;


### PR DESCRIPTION
Added bindings to the furi memory allocator. 
Alloc crate should be usable now.

How to use: do nothing, #[global_allocator] will automatically wire it.
Comments:
- Tested on @twitchyliquid64 fz-rust example + vec/string usage.
- Current `on_oom` implementation is rather simple, feel free to propose what should be there or freely modify it. I'm not sure flipper would be able to properly allocate c_string on OOM (in tests I just see that somewhere furi_check fails and flipper reboots)