### PR TITLE
0.2-dev: LF-RFID emulation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/alloc",
     "crates/flipperzero",
     "crates/sys",
 ]

--- a/crates/alloc/.gitignore
+++ b/crates/alloc/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/crates/alloc/Cargo.toml
+++ b/crates/alloc/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "flipperzero-alloc"
+version = "0.1.0"
+description = "Rust for Flipper Zero"
+repository = "https://github.com/dcoles/flipperzero-rs"
+license = "MIT"
+edition = "2021"
+autobins = false
+autoexamples = false
+autotests = false
+autobenches = false
+
+[package.metadata.docs.rs]
+default-target = "thumbv7em-none-eabihf"
+targets = []
+all-features = true
+
+[lib]
+bench = false
+test = false
+
+[dependencies]
+flipperzero-sys = { path = "../sys", version = "0.2.0-alpha" }

--- a/crates/alloc/README.md
+++ b/crates/alloc/README.md
@@ -1,0 +1,5 @@
+# `flipperzero-alloc`
+
+Global allocator support for the [Flipper Zero](https://flipperzero.one/).
+
+**Note:** This currently requires being compiled with a nightly Rust release.

--- a/crates/alloc/src/lib.rs
+++ b/crates/alloc/src/lib.rs
@@ -1,0 +1,42 @@
+//! Alloc support for the Flipper Zero.
+//! *Note:* This currently requires using nightly.
+
+#![no_std]
+#![feature(alloc_error_handler)]
+
+use core::alloc::{GlobalAlloc, Layout};
+use core::ffi::c_void;
+
+use flipperzero_sys as sys;
+use sys::c_string;
+
+pub struct FuriAlloc;
+
+unsafe impl GlobalAlloc for FuriAlloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        sys::furi::memmgr::aligned_malloc(layout.size(), layout.align()) as *mut u8
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        sys::furi::memmgr::aligned_free(ptr as *mut c_void);
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // https://github.com/flipperdevices/flipperzero-firmware/issues/1747#issuecomment-1253636552
+        self.alloc(layout)
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: FuriAlloc = FuriAlloc;
+
+#[alloc_error_handler]
+fn on_oom(_layout: Layout) -> ! {
+    unsafe {
+        sys::furi::thread::yield_();
+        sys::furi::check::crash(c_string!("Rust: Out of Memory\r\n"))
+    }
+}

--- a/crates/flipperzero/src/lib.rs
+++ b/crates/flipperzero/src/lib.rs
@@ -4,3 +4,17 @@
 
 pub mod furi;
 pub mod panic_handler;
+
+#[macro_export]
+macro_rules! print {
+    ($($args:tt)*) => {
+        core::write!($crate::furi::io::Stdout, $($args)*).unwrap()
+    };
+}
+
+#[macro_export]
+macro_rules! println {
+    ($pat:expr, $($args:tt)*) => {
+        core::write!($crate::furi::io::Stdout, core::concat!($pat, "\r\n"), $($args)*).unwrap()
+    };
+}

--- a/crates/sys/src/lfrfid.rs
+++ b/crates/sys/src/lfrfid.rs
@@ -1,0 +1,24 @@
+//! Low-level bindings to the LF-RFID API.
+
+pub mod worker {
+    use crate::opaque;
+    use crate::toolbox::protocols;
+
+    opaque!(Worker);
+
+    extern "C" {
+        #[link_name="lfrfid_worker_alloc"]
+        pub fn lfrfid_worker_alloc(dict: *mut protocols::Dict) -> *mut Worker;
+        #[link_name="lfrfid_worker_free"]
+        pub fn lfrfid_worker_free(worker: *mut Worker);
+        #[link_name="lfrfid_worker_start_thread"]
+        pub fn lfrfid_worker_start_thread(worker: *mut Worker);
+        #[link_name="lfrfid_worker_stop_thread"]
+        pub fn lfrfid_worker_stop_thread(worker: *mut Worker);
+
+        #[link_name="lfrfid_worker_emulate_start"]
+        pub fn lfrfid_worker_emulate_start(worker: *mut Worker, protocol_id: protocols::ProtocolId);
+        #[link_name="lfrfid_worker_stop"]
+        pub fn lfrfid_worker_stop(worker: *mut Worker);
+    }
+}

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -6,8 +6,8 @@ pub mod canvas;
 pub mod furi;
 pub mod gui;
 pub mod icon;
-pub mod notification;
 pub mod lfrfid;
+pub mod notification;
 pub mod toolbox;
 pub mod view_port;
 

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -7,6 +7,8 @@ pub mod furi;
 pub mod gui;
 pub mod icon;
 pub mod notification;
+pub mod lfrfid;
+pub mod toolbox;
 pub mod view_port;
 
 /// Declare an opaque type.

--- a/crates/sys/src/toolbox/mod.rs
+++ b/crates/sys/src/toolbox/mod.rs
@@ -1,0 +1,3 @@
+//! Low-level toolbox bindings.
+
+pub mod protocols;

--- a/crates/sys/src/toolbox/protocols.rs
+++ b/crates/sys/src/toolbox/protocols.rs
@@ -1,0 +1,28 @@
+//! Low-level bindings to the Protocols API.
+
+use core::ffi::c_char;
+use crate::opaque;
+
+opaque!(ProtocolsArray);
+
+/// The number of entries in LFRFID_PROTOCOLS.
+pub const PROTOCOLS_MAX: usize = 16; // SDK version 1.13
+
+opaque!(Dict);
+
+#[repr(transparent)]
+pub struct ProtocolId(i32);
+
+extern "C" {
+    #[link_name="lfrfid_protocols"]
+    pub static LFRFID_PROTOCOLS: ProtocolsArray;
+
+    #[link_name="protocol_dict_alloc"]
+    pub fn protocol_dict_alloc(protocols: &'static ProtocolsArray, num_protocols: usize) -> *mut Dict;
+    #[link_name="protocol_dict_free"]
+    pub fn protocol_dict_free(dict: *mut Dict);
+    #[link_name="protocol_dict_get_protocol_by_name"]
+    pub fn protocol_dict_get_protocol_by_name(dict: *mut Dict, name: *const c_char) -> ProtocolId;
+    #[link_name="protocol_dict_set_data"]
+    pub fn protocol_dict_set_data(dict: *mut Dict, protocol_id: ProtocolId, data: *const u8, data_len: usize);
+}


### PR DESCRIPTION
Could use some advice on appropriate types, in particular what to do about `PROTOCOLS_MAX`.

I was able to open the front door of my apartment complex with this code:

```rust
let dict = protocol_dict_alloc(&LFRFID_PROTOCOLS, PROTOCOLS_MAX);
let protocol_id = protocol_dict_get_protocol_by_name(dict, sys::c_string!("H10301"));

let mut data: [u8; 3] = [<REDACTED>];
protocol_dict_set_data(dict, protocol_id, data.as_ptr(), 3);

let rf_worker = lfrfid_worker_alloc(dict);
lfrfid_worker_start_thread(rf_worker);
lfrfid_worker_emulate_start(rf_worker, protocol_id);

// wait for user input

lfrfid_worker_stop(rf_worker);
lfrfid_worker_stop_thread(rf_worker);
lfrfid_worker_free(rf_worker);
protocol_dict_free(dict);
```