### PR TITLE
Implement bindings for elements & variable_item_list widgets

### DIFF
--- a/crates/sys/src/gui/elements.rs
+++ b/crates/sys/src/gui/elements.rs
@@ -1,0 +1,16 @@
+//! Low-level bindings to Elements API.
+
+use core::ffi::c_char;
+use super::canvas::{Align, Canvas};
+
+extern "C" {
+    #[link_name = "elements_button_left"]
+    pub fn button_left(canvas: *mut Canvas, label: *const c_char);
+    #[link_name = "elements_button_center"]
+    pub fn button_center(canvas: *mut Canvas, label: *const c_char);
+    #[link_name = "elements_button_right"]
+    pub fn button_right(canvas: *mut Canvas, label: *const c_char);
+
+    #[link_name = "elements_multiline_text_aligned"]
+    pub fn multiline_text_aligned(canvas: *mut Canvas, x: u8, y: u8, horizontal: Align, vertical: Align, label: *const c_char);
+}

--- a/crates/sys/src/gui/mod.rs
+++ b/crates/sys/src/gui/mod.rs
@@ -5,6 +5,8 @@ use core::ffi::c_char;
 use core::fmt::Display;
 
 pub mod canvas;
+pub mod elements;
+pub mod variable_item_list;
 pub mod view;
 pub mod view_dispatcher;
 pub mod view_port;

--- a/crates/sys/src/gui/variable_item_list.rs
+++ b/crates/sys/src/gui/variable_item_list.rs
@@ -1,0 +1,37 @@
+//! Low-level bindings to the variable-item list view.
+
+use core::ffi::{c_char, c_void};
+use crate::gui::view::View;
+use crate::opaque;
+
+opaque!(VariableItem);
+opaque!(VariableItemList);
+
+pub type ChangeCallback = extern "C" fn(*mut VariableItem);
+pub type EnterCallback = extern "C" fn(*mut c_void, u32);
+
+extern "C" {
+    #[link_name = "variable_item_list_alloc"]
+    pub fn alloc() -> *mut VariableItemList;
+    #[link_name = "variable_item_list_free"]
+    pub fn free(vil: *mut VariableItemList);
+    #[link_name = "variable_item_list_get_view"]
+    pub fn get_view(vil: *mut VariableItemList) -> *mut View;
+
+    #[link_name = "variable_item_list_add"]
+    pub fn add_item(vil: *mut VariableItemList, label: *const c_char, count: u8, change_callback: ChangeCallback, context: *mut c_void) -> *mut VariableItem;
+    #[link_name = "variable_item_list_get_selected_item_index"]
+    pub fn selected_index(vil: *mut VariableItemList) -> u8;
+
+    #[link_name = "variable_item_list_set_enter_callback"]
+    pub fn set_enter_callback(vil: *mut VariableItemList, callback: EnterCallback);
+
+    #[link_name = "variable_item_get_current_value_index"]
+    pub fn get_current_value_index(vi: *mut VariableItem) -> u8;
+    #[link_name = "variable_item_set_current_value_index"]
+    pub fn set_current_value_index(vi: *mut VariableItem, idx: u8);
+    #[link_name = "variable_item_set_current_value_text"]
+    pub fn set_current_value_text(vi: *mut VariableItem, label: *const c_char);
+    #[link_name = "variable_item_get_context"]
+    pub fn get_context(vi: *mut VariableItem) -> *mut c_void;
+}

--- a/crates/sys/src/gui/view.rs
+++ b/crates/sys/src/gui/view.rs
@@ -8,7 +8,6 @@ opaque!(View);
 pub type DrawCallback = extern "C" fn(*mut super::canvas::Canvas, *mut c_void);
 pub type InputCallback = extern "C" fn(*mut super::InputEvent, *mut c_void) -> bool;
 pub type CustomCallback = extern "C" fn(u32, *mut c_void) -> bool;
-pub type NavigationCallback = extern "C" fn(*mut c_void) -> u32;
 
 extern "C" {
     #[link_name = "view_alloc"]


### PR DESCRIPTION
The VIL in particular lets you make pretty config menus:

![image](https://user-images.githubusercontent.com/6328589/193685477-4b01d2b9-7e75-4eb8-b63a-201e8d21d376.png)

Whereas the elements API is just for consistent buttons and rendering and stuff:

![image](https://user-images.githubusercontent.com/6328589/193686335-b23ea178-9af9-47a9-a0d0-9871ed209629.png)
