### PR TITLE
Improve clang error readability

### DIFF
--- a/tools/src/bin/generate-bindings.rs
+++ b/tools/src/bin/generate-bindings.rs
@@ -194,7 +194,14 @@ fn main() {
         bindings = bindings.allowlist_var(variable);
     }
 
-    let bindings = bindings.generate().expect("failed to generate bindings");
+    let bindings = match bindings.generate() {
+        Ok(b) => b,
+        Err(e) => {
+            // Seperate errror output from the preceding clang diag output for legibility
+            println!("\n{}", e);
+            panic!("failed to generate bindings")
+        }
+    };
 
     // `-working-directory` also affects `Bindings::write_to_file`
     let outfile = cwd.join(OUTFILE);


### PR DESCRIPTION
Currently when clang fails the panic print includes the debug representation of `ClangDiagnostic` which doesn't have newlines so it's really hard to read:
```
thread 'main' panicked at 'failed to generate bindings: ClangDiagnostic("H:/002_Mojurasu/projects/flipper/flipperzero-rs/tools/../../official/build/latest/sdk/f7_sdk/lib/STM32CubeWB/Drivers/CMSIS/Include/cmsis_compiler.h:278:4: error: Unknown compiler.\nH:\\002_Mojurasu\\projects\\flipper\\flipperzero-rs\\tools\\../../official/build/latest/sdk\\../../../toolchain/x86_64-windows/arm-none-eabi/include\\string.h:172:55: error: expected string literal in 'asm'\nC:\\Program Files\\LLVM\\lib\\clang\\12.0.0\\include\\emmintrin.h:4224:6: error: conflicting types for '_mm_clflush'\nC:\\Program Files\\LLVM\\lib\\clang\\12.0.0\\include\\intrin.h:155:15: error: conflicting types for '_bittest'\n[...]
```
With this it will now print a newline to separate the error from the previous `clang diag` output and properly print newlines:
```
clang diagnosed error: H:/002_Mojurasu/projects/flipper/flipperzero-rs/tools/../../official/build/latest/sdk/f7_sdk/lib/STM32CubeWB/Drivers/CMSIS/Include/cmsis_compiler.h:278:4: error: Unknown compiler.
H:\002_Mojurasu\projects\flipper\flipperzero-rs\tools\../../official/build/latest/sdk\../../../toolchain/x86_64-windows/arm-none-eabi/include\string.h:172:55: error: expected string literal in 'asm'
C:\Program Files\LLVM\lib\clang\12.0.0\include\emmintrin.h:4224:6: error: conflicting types for '_mm_clflush'
C:\Program Files\LLVM\lib\clang\12.0.0\include\intrin.h:155:15: error: conflicting types for '_bittest'
```


