### PR TITLE
feat: allow trailing comas in function-like macro calls

### DIFF
--- a/crates/flipperzero/src/macros.rs
+++ b/crates/flipperzero/src/macros.rs
@@ -2,7 +2,7 @@
 
 #[macro_export]
 macro_rules! print {
-    ($pat:expr, $($args:tt)* $(,)?) => {{
+    ($pat:expr, $($args:tt)*) => {{
         $crate::furi::io::_print(core::format_args!($pat, $($args)*));
     }};
 
@@ -13,7 +13,7 @@ macro_rules! print {
 
 #[macro_export]
 macro_rules! println {
-    ($pat:expr, $($args:tt)* $(,)?) => {{
+    ($pat:expr, $($args:tt)*) => {{
         $crate::furi::io::_print(core::format_args!(concat!($pat, "\r\n"), $($args)*));
     }};
 

--- a/crates/flipperzero/src/macros.rs
+++ b/crates/flipperzero/src/macros.rs
@@ -2,22 +2,22 @@
 
 #[macro_export]
 macro_rules! print {
-    ($pat:expr, $($args:tt)*) => {{
+    ($pat:expr, $($args:tt)* $(,)?) => {{
         $crate::furi::io::_print(core::format_args!($pat, $($args)*));
     }};
 
-    ($msg:expr) => {{
+    ($msg:expr $(,)?) => {{
         $crate::furi::io::_write_str($msg);
     }};
 }
 
 #[macro_export]
 macro_rules! println {
-    ($pat:expr, $($args:tt)*) => {{
+    ($pat:expr, $($args:tt)* $(,)?) => {{
         $crate::furi::io::_print(core::format_args!(concat!($pat, "\r\n"), $($args)*));
     }};
 
-    ($msg:expr) => {{
+    ($msg:expr $(,)?) => {{
         $crate::furi::io::_write_str(concat!($msg, "\r\n"));
     }};
 }

--- a/crates/rt/src/manifest.rs
+++ b/crates/rt/src/manifest.rs
@@ -23,7 +23,7 @@ const DEFAULT_STACK_SIZE: u16 = 2048; // 2 KiB
 /// ```
 #[macro_export]
 macro_rules! manifest {
-    ($($field:ident = $value:tt),*) => {
+    ($($field:ident = $value:expr),* $(,)?) => {
         #[no_mangle]
         #[link_section = ".fapmeta"]
         static FAP_MANIFEST: $crate::manifest::ApplicationManifestV1 = $crate::manifest::ApplicationManifestV1 {

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -13,7 +13,7 @@ mod bindings;
 /// Will automatically add a NUL terminator.
 #[macro_export]
 macro_rules! c_string {
-    ($str:literal) => {{
+    ($str:literal $(,)?) => {{
         concat!($str, "\0").as_ptr() as *const core::ffi::c_char
     }};
 }
@@ -21,7 +21,7 @@ macro_rules! c_string {
 /// Crash the system.
 #[macro_export]
 macro_rules! crash {
-    ($msg:literal) => {
+    ($msg:literal $(,)?) => {
         unsafe {
             // Crash message is passed via r12
             let msg = $crate::c_string!($msg);

--- a/examples/hello-rust/src/main.rs
+++ b/examples/hello-rust/src/main.rs
@@ -13,9 +13,10 @@ use flipperzero_rt::{entry, manifest};
 // Define the FAP Manifest for this application
 manifest!(
     name = "Hello, Rust!",
+    app_version = 1,
     has_icon = true,
     // See `docs/icons.md` for icon format
-    icon = "rustacean-10x10.icon"
+    icon = "rustacean-10x10.icon",
 );
 
 // Define the entry function


### PR DESCRIPTION
# Description

This allows using trailing comas in function-like macro calls.

This affects all public macros except for `entry!`
which generally looks like a good atrtibute-macro candidate.
