### PR TITLE
build: fix build of `crates` inIntellij-based IDEs

### DIFF
--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -20,4 +20,4 @@ rustflags = [
 ]
 
 [build]
-target = ["thumbv7em-none-eabihf"]
+target = "thumbv7em-none-eabihf"


### PR DESCRIPTION
# Description

This fixes build of `crates` module in Intellij-based IDEs.

Previous configuration would cause errors while trying to configure Cargo-based project.